### PR TITLE
Add tests for flash messages for happy and sad paths

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -8,7 +8,7 @@ class Admin::MerchantsController < ApplicationController
 
   def show
   end
-  
+
   def create
     @merchant = Merchant.new(m_params)
     @merchant.save
@@ -20,11 +20,15 @@ class Admin::MerchantsController < ApplicationController
   end
 
   def update
-    @merchant.update(merchant_params)
-    flash.notice = 'Merchant Has Been Updated!'
-    redirect_to admin_merchant_path(@merchant)
+    if @merchant.update(merchant_params)
+      flash.notice = "Merchant Has Been Updated!"
+      redirect_to admin_merchant_path(@merchant)
+    else
+      flash.notice = "All fields must be completed, get your act together."
+      redirect_to edit_admin_merchant_path(@merchant)
+    end
   end
-  
+
   private
   def set_merchant
     @merchant = Merchant.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,9 +16,13 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @item.update(item_params_sec)
-    flash.notice = "Succesfully Updated Item Info!"
-    redirect_to merchant_item_path(@merchant, @item)
+    if @item.update(item_params_sec)
+      flash.notice = "Succesfully Updated Item Info!"
+      redirect_to merchant_item_path(@merchant, @item)
+    else
+      flash.notice = "All fields must be completed, get your act together."
+      redirect_to edit_merchant_item_path(@merchant, @item)
+    end
   end
 
   def new

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -6,11 +6,21 @@ describe 'Admin Merchant Show' do
     visit edit_admin_merchant_path(@m1)
   end
 
-  it 'should have a form that redirects back to admin merchant show' do
+  it 'should have a form that redirects back to admin merchant show with a flash message' do
     fill_in 'merchant[name]', with: 'Dang Boiii'
     click_button
 
     expect(current_path).to eq(admin_merchant_path(@m1))
     expect(page).to have_content('Dang Boiii')
+    expect(page).to have_content("Merchant Has Been Updated!")
+  end
+
+  it "shows a flash message if not all sections are filled in" do
+    fill_in "Name", with: ""
+
+    click_button
+
+    expect(current_path).to eq(edit_admin_merchant_path(@m1))
+    expect(page).to have_content("All fields must be completed, get your act together.")
   end
 end

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -8,5 +8,6 @@ describe 'Admin Merchant New' do
 
     expect(current_path).to eq(admin_merchants_path)
     expect(page).to have_content('Dingley Doo')
+    expect(page).to have_content('Merchant Has Been Created!')
   end
 end

--- a/spec/features/items/edit_spec.rb
+++ b/spec/features/items/edit_spec.rb
@@ -34,4 +34,15 @@ describe "merchant items edit page" do
     expect(page).to have_no_content("This washes your hair")
     expect(page).to have_content("Succesfully Updated Item Info!")
   end
+  it "shows a flash message if not all sections are filled in" do
+    visit edit_merchant_item_path(@merchant1, @item_1)
+
+    fill_in "Name", with: ""
+    fill_in "Description", with: "Eco friendly shampoo"
+    fill_in "Unit price", with: "15"
+
+    click_button "Submit"
+    expect(current_path).to eq(edit_merchant_item_path(@merchant1, @item_1))
+    expect(page).to have_content("All fields must be completed, get your act together.")
+  end
 end


### PR DESCRIPTION
-Add tests for edit/new pages for admin and merchants that test flash messages for happy and sad paths(when a form isn't completed before submitting)
